### PR TITLE
Changed configuration to use rollup

### DIFF
--- a/fableconfig.json
+++ b/fableconfig.json
@@ -1,9 +1,9 @@
 {
     "module": "commonjs",
-    "outDir": "out",
+    "rollup": {"dest":"./out/main.js"},
     "sourceMaps": false,
     "projFile": "./Screeps.fsproj",
     "engines": {
-        "fable": "0.6.7"
+        "fable": "0.7.28"
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,12 @@
     "clean:deploy": "rm -rfv /Users/rkilkenny/Library/Application\\ Support/Screeps/scripts/screeps.com/fable/*",
     "compile": "fable",
     "bablify": "babel out/src --out-file out/main.js",
-    "deploy:scripts": "cp -R ./out/src/* /Users/rkilkenny/Library/Application\\ Support/Screeps/scripts/screeps.com/fable",
-    "start": "npm run clean:out && npm run compile && npm run clean:deploy && npm run deploy:fable && npm run deploy:scripts",
-    "deploy:fable": "cp ./node_modules/fable-core/fable-core.min.js /Users/rkilkenny/Library/Application\\ Support/Screeps/scripts/screeps.com/fable/fable-core.js"
+    "deploy:script": "cp ./out/main.js /Users/rkilkenny/Library/Application\\ Support/Screeps/scripts/screeps.com/fable",
+    "start": "npm run clean:out && npm run compile && npm run clean:deploy && npm run deploy:script"
   },
   "dependencies": {
     "fable": "^1.0.1",
-    "fable-core": "^0.6.7"
+    "fable-core": "^0.7.28"
   },
   "devDependencies": {
     "typings": "^1.4.0"


### PR DESCRIPTION
By using rollup, the compiled library, src, and fable-core files are combined into a single js file. This should simplify the deploy, as well as allowing for more complex folder hierarchies in the F# project. Also ensures that the fable library is always included at the correct version (less fragile than using fable-core.min.js).

I didn't mess with your deploy locations, etc. as that's pretty easy to configure (though making the deployment part of the script work on Windows is a headache, since rm doesn't exist and del doesn't behave the same way in addition to access rights annoyances copying to the Local AppData folder unprivileged). Rollup definitely eliminates several of those annoyances.